### PR TITLE
Add maskByValue function to scala, sql, and py apis.

### DIFF
--- a/core/src/main/scala/astraea/spark/rasterframes/RasterFunctions.scala
+++ b/core/src/main/scala/astraea/spark/rasterframes/RasterFunctions.scala
@@ -303,6 +303,12 @@ trait RasterFunctions {
       udf(F.mask).apply(sourceTile, maskTile)
     ).as[Tile]
 
+  /** Where the mask tile equals the mask value, replace values in the source tile with NODATA */
+  def maskByValue(sourceTile: Column, maskTile: Column, maskValue: Column): TypedColumn[Any, Tile] =
+    withAlias("maskByValue", sourceTile, maskTile, maskValue)(
+      udf(F.maskByValue).apply(sourceTile, maskTile, maskValue)
+    ).as[Tile]
+
   /** Where the mask tile DOES NOT contain NODATA, replace values in the source tile with NODATA */
   def inverseMask(sourceTile: Column, maskTile: Column): TypedColumn[Any, Tile] =
     withAlias("inverseMask", sourceTile, maskTile)(

--- a/core/src/main/scala/astraea/spark/rasterframes/functions/package.scala
+++ b/core/src/main/scala/astraea/spark/rasterframes/functions/package.scala
@@ -337,6 +337,14 @@ package object functions {
 
   /**
     * Generate a tile with the values from the data tile, but where cells in the
+    * masking tile contain the masking value, replace the data value with NODATA.
+    */
+  private[rasterframes] val maskByValue: (Tile, Tile, Int) ⇒ Tile =
+    (dataTile, maskingTile, maskingValue) ⇒
+      Mask(dataTile, maskingTile, maskingValue, NODATA)
+
+  /**
+    * Generate a tile with the values from the data tile, but where cells in the
     * masking tile DO NOT contain NODATA, replace the data value with NODATA.
     */
   private[rasterframes] val inverseMask: (Tile, Tile) ⇒ Tile =
@@ -449,6 +457,7 @@ package object functions {
 
   def register(sqlContext: SQLContext): Unit = {
     sqlContext.udf.register("rf_mask", mask)
+    sqlContext.udf.register("rf_maskByValue", maskByValue)
     sqlContext.udf.register("rf_inverseMask", inverseMask)
     sqlContext.udf.register("rf_makeConstantTile", makeConstantTile)
     sqlContext.udf.register("rf_tileZeros", tileZeros)

--- a/core/src/test/scala/astraea/spark/rasterframes/GTSQLSpec.scala
+++ b/core/src/test/scala/astraea/spark/rasterframes/GTSQLSpec.scala
@@ -94,6 +94,20 @@ class GTSQLSpec extends TestEnvironment with TestData  {
         assertEqual(result.first(), expected)
       }
 
+      withClue("mask by value") {
+        val ds = Seq[(Tile, Tile)]((byteArrayTile, byteArrayTile)).toDF("left", "right")
+        val result = ds.select(maskByValue($"left", $"right", lit(8)))
+        val resultSql = {
+          ds.createOrReplaceTempView("maskByValue")
+          spark.sql("SELECT rf_maskByValue(left, right, 8) as x FROM maskByValue")
+        }
+
+        val expected = ByteArrayTile(Array[Byte](1, 2, 3, 4, 5, 6, 7, byteNODATA, 9), 3, 3)
+
+        assertEqual(result.first(), expected)
+        assertEqual(resultSql.first().getAs[Tile](0), expected)
+      }
+
       withClue("inverse mask") {
         val ds = Seq[(Tile, Tile)]((byteArrayTile, maskingTile)).toDF("left", "right")
         val result = ds.select(inverseMask($"left", $"right"))

--- a/pyrasterframes/python/pyrasterframes/rasterfunctions.py
+++ b/pyrasterframes/python/pyrasterframes/rasterfunctions.py
@@ -176,7 +176,6 @@ _rf_column_functions = {
     'localAggDataCells': 'Compute the cellwise/local count of non-NoData cells for all Tiles in a column.',
     'localAggNoDataCells': 'Compute the cellwise/local count of NoData cells for all Tiles in a column.',
     'mask': 'Where the mask (second) tile contains NODATA, replace values in the source (first) tile with NODATA.',
-    'maskByValue': 'Where the mask (second) tile equals maskValue, replace values in the source (first) tile with NODATA',
     'inverseMask': 'Where the mask (second) tile DOES NOT contain NODATA, replace values in the source (first) tile with NODATA.',
     'localLess': 'Cellwise less than comparison between two tiles',
     'localLessEqual': 'Cellwise less than or equal to comparison between two tiles',

--- a/pyrasterframes/python/pyrasterframes/rasterfunctions.py
+++ b/pyrasterframes/python/pyrasterframes/rasterfunctions.py
@@ -176,6 +176,7 @@ _rf_column_functions = {
     'localAggDataCells': 'Compute the cellwise/local count of non-NoData cells for all Tiles in a column.',
     'localAggNoDataCells': 'Compute the cellwise/local count of NoData cells for all Tiles in a column.',
     'mask': 'Where the mask (second) tile contains NODATA, replace values in the source (first) tile with NODATA.',
+    'maskByValue': 'Where the mask (second) tile equals maskValue, replace values in the source (first) tile with NODATA',
     'inverseMask': 'Where the mask (second) tile DOES NOT contain NODATA, replace values in the source (first) tile with NODATA.',
     'localLess': 'Cellwise less than comparison between two tiles',
     'localLessEqual': 'Cellwise less than or equal to comparison between two tiles',


### PR DESCRIPTION
Function to mask tile `T1` where tile `T2` equals `v`

Use cases would be cloud or snow masks from data producers. 

Signed-off-by: Jason T. Brown <jason@astraea.earth>