### PR TITLE
Fix scalar arithmetic and noDataFilter array conversion

### DIFF
--- a/core/src/main/scala/astraea/spark/rasterframes/ml/NoDataFilter.scala
+++ b/core/src/main/scala/astraea/spark/rasterframes/ml/NoDataFilter.scala
@@ -40,7 +40,7 @@ class NoDataFilter (override val uid: String) extends Transformer
   def this() = this(Identifiable.randomUID("nodata-filter"))
   final def setInputCols(value: Array[String]): NoDataFilter = set(inputCols, value)
   final def setInputCols(values: ArrayList[String]): this.type = {
-    val valueArr = values.toArray[String]
+    val valueArr = Array[String](values:_*)
     set(inputCols, valueArr)
   }
 

--- a/pyrasterframes/python/pyrasterframes/rasterfunctions.py
+++ b/pyrasterframes/python/pyrasterframes/rasterfunctions.py
@@ -130,15 +130,25 @@ _rf_unique_functions = {
 _rf_column_scalar_functions = {
     'withNoData': 'Assign a `NoData` value to the Tiles in the given Column.',
     'localAddScalar': 'Add a scalar to a Tile',
+    'localAddScalarInt': 'Add a scalar to a Tile',
     'localSubtractScalar': 'Subtract a scalar from a Tile',
+    'localSubtractScalarInt': 'Subtract a scalar from a Tile',
     'localMultiplyScalar': 'Multiply a Tile by a scalar',
+    'localMultiplyScalarInt': 'Multiply a Tile by a scalar',
     'localDivideScalar': 'Divide a Tile by a scalar',
+    'localDivideScalarInt': 'Divide a Tile by a scalar',
     'localLessScalar': 'Return a Tile with values equal 1 if the cell is less than a scalar, otherwise 0',
+    'localLessScalarInt': 'Return a Tile with values equal 1 if the cell is less than a scalar, otherwise 0',
     'localLessEqualScalar': 'Return a Tile with values equal 1 if the cell is less than or equal to a scalar, otherwise 0',
+    'localLessEqualScalarInt': 'Return a Tile with values equal 1 if the cell is less than or equal to a scalar, otherwise 0',
     'localGreaterScalar': 'Return a Tile with values equal 1 if the cell is greater than a scalar, otherwise 0',
+    'localGreaterScalarInt': 'Return a Tile with values equal 1 if the cell is greater than a scalar, otherwise 0',
     'localGreaterEqualScalar': 'Return a Tile with values equal 1 if the cell is greater than or equal to a scalar, otherwise 0',
+    'localGreaterEqualScalarInt': 'Return a Tile with values equal 1 if the cell is greater than or equal to a scalar, otherwise 0',
     'localEqualScalar': 'Return a Tile with values equal 1 if the cell is equal to a scalar, otherwise 0',
+    'localEqualScalarInt': 'Return a Tile with values equal 1 if the cell is equal to a scalar, otherwise 0',
     'localUnequalScalar': 'Return a Tile with values equal 1 if the cell is not equal to a scalar, otherwise 0',
+    'localUnequalScalarInt': 'Return a Tile with values equal 1 if the cell is not equal to a scalar, otherwise 0',
 }
 
 

--- a/pyrasterframes/src/main/scala/astraea/spark/rasterframes/py/PyRFContext.scala
+++ b/pyrasterframes/src/main/scala/astraea/spark/rasterframes/py/PyRFContext.scala
@@ -119,9 +119,49 @@ class PyRFContext(implicit sparkSession: SparkSession) extends RasterFunctions
   def temporalKeyColumn(df: DataFrame): Column =
     df.asRF.temporalKeyColumn.orNull
 
+  def localAddScalar(col: Column, scalar: Double): Column = localAddScalar[Double](col, scalar)
+
+  def localAddScalarInt(col: Column, scalar: Int): Column = localAddScalar[Int](col, scalar)
+
+  def localSubtractScalar(col: Column, scalar: Double): Column = localSubtractScalar[Double](col, scalar)
+
+  def localSubtractScalarInt(col: Column, scalar: Int): Column = localSubtractScalar[Int](col, scalar)
+
+  def localDivideScalar(col: Column, scalar: Double): Column = localDivideScalar[Double](col, scalar)
+
+  def localDivideScalarInt(col: Column, scalar: Int): Column = localDivideScalar[Int](col, scalar)
+
+  def localMultiplyScalar(col: Column, scalar: Double): Column = localMultiplyScalar[Double](col, scalar)
+
+  def localMultiplyScalarInt(col: Column, scalar: Int): Column = localMultiplyScalar[Int](col, scalar)
+
   def tileToIntArray(col: Column): Column = tileToArray[Int](col)
 
   def tileToDoubleArray(col: Column): Column = tileToArray[Double](col)
+
+  def localLessScalar(col: Column, scalar: Double): Column = localLessScalar[Double](col, scalar)
+
+  def localLessScalarInt(col: Column, scalar: Int): Column = localLessScalar[Int](col, scalar)
+
+  def localLessEqualScalar(col: Column, scalar: Double): Column = localLessEqualScalar[Double](col, scalar)
+
+  def localLessEqualScalarInt(col: Column, scalar: Int): Column = localLessEqualScalar[Int](col, scalar)
+
+  def localGreaterScalar(col: Column, scalar: Double): Column = localGreaterScalar[Double](col, scalar)
+
+  def localGreaterScalarInt(col: Column, scalar: Int): Column = localGreaterScalar[Int](col, scalar)
+
+  def localGreaterEqualScalar(col: Column, scalar: Double): Column = localGreaterEqualScalar[Double](col, scalar)
+
+  def localGreaterEqualScalarInt(col: Column, scalar: Int): Column = localGreaterEqualScalar[Int](col, scalar)
+
+  def localEqualScalar(col: Column, scalar: Double): Column = localEqualScalar[Double](col, scalar)
+
+  def localEqualScalarInt(col: Column, scalar: Int): Column = localEqualScalar[Int](col, scalar)
+
+  def localUnequalScalar(col: Column, scalar: Double): Column = localUnequalScalar[Double](col, scalar)
+
+  def localUnequalScalarInt(col: Column, scalar: Int): Column = localUnequalScalar[Int](col, scalar)
 
   // return toRaster, get just the tile, and make an array out of it
   def toIntRaster(df: DataFrame, colname: String, cols: Int, rows: Int): Array[Int] = {

--- a/pyrasterframes/src/main/scala/astraea/spark/rasterframes/py/PyRFContext.scala
+++ b/pyrasterframes/src/main/scala/astraea/spark/rasterframes/py/PyRFContext.scala
@@ -119,6 +119,12 @@ class PyRFContext(implicit sparkSession: SparkSession) extends RasterFunctions
   def temporalKeyColumn(df: DataFrame): Column =
     df.asRF.temporalKeyColumn.orNull
 
+  def tileToIntArray(col: Column): Column = tileToArray[Int](col)
+
+  def tileToDoubleArray(col: Column): Column = tileToArray[Double](col)
+
+  // All the scalar tile arithmetic functions
+
   def localAddScalar(col: Column, scalar: Double): Column = localAddScalar[Double](col, scalar)
 
   def localAddScalarInt(col: Column, scalar: Int): Column = localAddScalar[Int](col, scalar)
@@ -134,10 +140,6 @@ class PyRFContext(implicit sparkSession: SparkSession) extends RasterFunctions
   def localMultiplyScalar(col: Column, scalar: Double): Column = localMultiplyScalar[Double](col, scalar)
 
   def localMultiplyScalarInt(col: Column, scalar: Int): Column = localMultiplyScalar[Int](col, scalar)
-
-  def tileToIntArray(col: Column): Column = tileToArray[Int](col)
-
-  def tileToDoubleArray(col: Column): Column = tileToArray[Double](col)
 
   def localLessScalar(col: Column, scalar: Double): Column = localLessScalar[Double](col, scalar)
 


### PR DESCRIPTION
Add aliases for scalar arithmetic, separating double and int implementations to deal with the scala numeric. Fix the way NoDataFilter converts from an arrayList to an array.