### PR TITLE
Python cell_types with snake case and return python list of strings; …

### DIFF
--- a/pyrasterframes/python/pyrasterframes/rasterfunctions.py
+++ b/pyrasterframes/python/pyrasterframes/rasterfunctions.py
@@ -154,7 +154,7 @@ def _create_maskByValue():
 _rf_unique_functions = {
     'array_to_tile': _create_arrayToTile(),
     'assemble_tile': _create_assembleTile(),
-    'cellTypes': lambda: _context_call('cellTypes'),
+    'cell_types': lambda: _context_call('cell_types'),
     'convert_cell_type': _create_convertCellType(),
     'explode_tiles': _create_explode_tiles(),
     'explode_tiles_sample': _create_explode_tiles_sample(),

--- a/pyrasterframes/src/main/scala/astraea/spark/rasterframes/py/PyRFContext.scala
+++ b/pyrasterframes/src/main/scala/astraea/spark/rasterframes/py/PyRFContext.scala
@@ -94,7 +94,13 @@ class PyRFContext(implicit sparkSession: SparkSession) extends RasterFunctions
     */
   def cell_type(name: String): CellType = CellType.fromName(name)
 
-  def cell_types: Seq[String] = astraea.spark.rasterframes.functions.cellTypes()
+  /**
+    * Convenience list of valid cell type strings
+    * @return Java List of String, which py4j can interpret as a python `list`
+    */
+  def cell_types = {
+    astraea.spark.rasterframes.functions.cellTypes().asJava
+  }
 
   /** DESERIALIZATION **/
 


### PR DESCRIPTION
Fixes #99 #98

No 0.7.x compatibility for camel case but that's true for all of python API, right?

Signed-off-by: Jason T. Brown <jason@astraea.earth>