### PR TITLE
Built in Tile __add__ etc follows numpy dtype conversions

### DIFF
--- a/pyrasterframes/python/pyrasterframes/__init__.py
+++ b/pyrasterframes/python/pyrasterframes/__init__.py
@@ -13,6 +13,7 @@ from .rf_types import *
 from . import rasterfunctions
 from .context import RFContext
 
+
 __all__ = ['RasterFrame', 'TileExploder']
 
 

--- a/pyrasterframes/python/pyrasterframes/rf_types.py
+++ b/pyrasterframes/python/pyrasterframes/rf_types.py
@@ -233,6 +233,8 @@ class CellType(object):
         return np.dtype(n).newbyteorder('>')
 
     def with_no_data_value(self, no_data):
+        if self.has_no_data() and self.no_data_value() == no_data:
+            return self
         return CellType(self.base_cell_type_name() + 'ud' + str(no_data))
 
     def __eq__(self, other):

--- a/pyrasterframes/python/pyrasterframes/rf_types.py
+++ b/pyrasterframes/python/pyrasterframes/rf_types.py
@@ -280,20 +280,36 @@ class Tile(object):
             other = right.cells
         else:
             other = right
-        return Tile(np.add(self.cells, other), self.cell_type)
+
+        _sum = np.add(self.cells, other)
+        ct = CellType.from_numpy_dtype(_sum.dtype)
+        if isinstance(_sum, np.ma.MaskedArray):
+            ct = ct.with_no_data_value(_sum.fill_value)
+
+        return Tile(_sum, ct)
 
     def __sub__(self, right):
         if isinstance(right, Tile):
             other = right.cells
         else:
             other = right
-        return Tile(np.subtract(self.cells, other), self.cell_type)
+        _diff = np.subtract(self.cells, other)
+        ct = CellType.from_numpy_dtype(_diff.dtype)
+        if isinstance(_diff, np.ma.MaskedArray):
+            ct = ct.with_no_data_value(_diff.fill_value)
+
+        return Tile(_diff, ct)
 
     def __mul__(self, right):
         if isinstance(right, Tile):
             other = right.cells
         else:
             other = right
+        prod = np.multiply(self.cells, other)
+        ct = CellType.from_numpy_dtype(prod.dtype)
+        if isinstance(prod, np.ma.MaskedArray):
+            ct = ct.with_no_data_value(prod.fill_value)
+
         return Tile(np.multiply(self.cells, other), self.cell_type)
 
     def __truediv__(self, right):
@@ -301,7 +317,11 @@ class Tile(object):
             other = right.cells
         else:
             other = right
-        return Tile(np.true_divide(self.cells, other), self.cell_type)
+        quot = np.true_divide(self.cells, other)
+        ct = CellType.from_numpy_dtype(quot.dtype)
+        if isinstance(quot, np.ma.MaskedArray):
+            ct = ct.with_no_data_value(quot.fill_value)
+        return Tile(quot, ct)
 
 
     def dimensions(self):

--- a/pyrasterframes/python/tests/PyRasterFramesTests.py
+++ b/pyrasterframes/python/tests/PyRasterFramesTests.py
@@ -451,15 +451,30 @@ class UDT(TestEnvironment):
 
         a1 = np.array([[1, 2], [0, 4]])
         t1 = Tile(a1, CellType.uint8())
-        exp_array = a1 * math.pi
+        exp_array = a1.astype('>f8')
 
         @udf(TileUDT())
         def times_pi(t):
             return t * math.pi
 
+        @udf(TileUDT())
+        def divide_pi(t):
+            return t / math.pi
+
+        @udf(TileUDT())
+        def plus_pi(t):
+            return t + math.pi
+
+        @udf(TileUDT())
+        def less_pi(t):
+            return t - math.pi
+
         df = self.spark.createDataFrame(pandas.DataFrame([{"tile": t1}]))
-        r1 = df.select(times_pi(df.tile)).first()[0]
-        self.assertTrue(np.all(r1.cells, exp_array))
+        r1 = df.select(
+            less_pi(divide_pi(times_pi(plus_pi(df.tile))))
+        ).first()[0]
+
+        self.assertTrue(np.all(r1.cells == exp_array))
         self.assertEqual(r1.cells.dtype, exp_array.dtype)
 
 


### PR DESCRIPTION
If a Python `rf_types.Tile` built in arithmetic function results in numpy converting the underlying dtype we will honor that in the returned Tile's `cell_type`. Also makes already merged unit test `test_udf_np_implicit_type_conversion` pass.



Signed-off-by: Jason T. Brown <jason@astraea.earth>