### PR TITLE
Upgraded gdal-warp-bindings

### DIFF
--- a/core/src/it/scala/org/locationtech/rasterframes/ref/RasterSourceIT.scala
+++ b/core/src/it/scala/org/locationtech/rasterframes/ref/RasterSourceIT.scala
@@ -24,6 +24,7 @@ package org.locationtech.rasterframes.ref
 import java.lang.Math.ceil
 import java.net.URI
 
+import com.azavea.gdal.GDALWarp
 import org.locationtech.rasterframes
 import org.locationtech.rasterframes.util.time
 import org.locationtech.rasterframes.{NOMINAL_TILE_SIZE, TestData, TestEnvironment}
@@ -63,7 +64,10 @@ class RasterSourceIT extends TestEnvironment with TestData {
   }
 
   if (RasterSource.IsGDAL.hasGDAL) {
+    println("GDAL version: " + GDALWarp.get_version_info("--version"))
+
     describe("GDAL support") {
+
 
       it("should read JPEG2000 scene") {
         RasterSource(localSentinel).readAll().flatMap(_.tile.statisticsDouble).size should be(64)

--- a/project/RFDependenciesPlugin.scala
+++ b/project/RFDependenciesPlugin.scala
@@ -62,6 +62,6 @@ object RFDependenciesPlugin extends AutoPlugin {
     rfSparkVersion := "2.3.2",
     rfGeoTrellisVersion := "2.2.0",
     rfGeoMesaVersion := "2.2.1",
-    dependencyOverrides += "com.azavea.gdal" % "gdal-warp-bindings" % "33.3f7a866"
+    dependencyOverrides += "com.azavea.gdal" % "gdal-warp-bindings" % "33.58d4965"
   )
 }


### PR DESCRIPTION
Currently core dumps on MacOS.

