### PR TITLE
Use implicit file:// for schemeless paths with leading /

### DIFF
--- a/core/src/main/scala/org/locationtech/rasterframes/ref/RasterSource.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/ref/RasterSource.scala
@@ -129,13 +129,18 @@ object RasterSource extends LazyLogging {
       } else false
 
     /** Extractor for determining if a scheme indicates GDAL preference.  */
-    def unapply(source: URI): Boolean =
-      gdalOnly(source) || ((preferGdal || source.getScheme.startsWith("gdal")) && GDALRasterSource.hasGDAL)
+    def unapply(source: URI): Boolean = {
+      lazy val schemeIsGdal = Option(source.getScheme())
+        .exists(_.startsWith("gdal"))
+
+      gdalOnly(source) || ((preferGdal || schemeIsGdal) && GDALRasterSource.hasGDAL)
+    }
   }
 
   object IsDefaultGeoTiff {
     def unapply(source: URI): Boolean = source.getScheme match {
-      case "file" | "http" | "https" | "s3" | "" => true
+      case "file" | "http" | "https" | "s3" => true
+      case null | ""                        ⇒ true
       case _                                => false
     }
   }

--- a/core/src/test/scala/org/locationtech/rasterframes/ref/RasterSourceSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/ref/RasterSourceSpec.scala
@@ -106,6 +106,12 @@ class RasterSourceSpec extends TestEnvironment with TestData {
       val src = RasterSource(localSrc)
       assert(!src.extent.isEmpty)
     }
+    it("should interpret no scheme as file://"){
+      val localSrc = geotiffDir.resolve("LC08_B7_Memphis_COG.tiff").toString()
+      val schemelessUri = new URI(localSrc)
+      val src = RasterSource(schemelessUri)
+      assert(!src.extent.isEmpty)
+    }
   }
 
   if(GDALRasterSource.hasGDAL) {

--- a/core/src/test/scala/org/locationtech/rasterframes/ref/RasterSourceSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/ref/RasterSourceSpec.scala
@@ -109,6 +109,7 @@ class RasterSourceSpec extends TestEnvironment with TestData {
     it("should interpret no scheme as file://"){
       val localSrc = geotiffDir.resolve("LC08_B7_Memphis_COG.tiff").toString()
       val schemelessUri = new URI(localSrc)
+      schemelessUri.getScheme should be (null)
       val src = RasterSource(schemelessUri)
       assert(!src.extent.isEmpty)
     }
@@ -137,6 +138,15 @@ class RasterSourceSpec extends TestEnvironment with TestData {
         val gdal = GDALRasterSource(archiveURI)
 
         gdal.bandCount should be (3)
+      }
+
+      it("should interpret no scheme as file://") {
+        val localSrc = geotiffDir.resolve("LC08_B7_Memphis_COG.tiff").toString()
+        val schemelessUri = new URI(localSrc)
+        val gdal = GDALRasterSource(schemelessUri)
+        val jvm = JVMGeoTiffRasterSource(schemelessUri)
+        gdal.extent should be (jvm.extent)
+        gdal.cellSize should be(jvm.cellSize)
       }
     }
   }

--- a/pyrasterframes/src/main/python/docs/raster-write.pymd
+++ b/pyrasterframes/src/main/python/docs/raster-write.pymd
@@ -66,7 +66,7 @@ Fortunately, we can use the cluster computing capability to downsample the data 
 
 ```python write_geotiff
 outfile = os.path.join('/tmp', 'geotiff-overview.tif')
-spark_df.write.geotiff('file://' + outfile, crs='EPSG:4326', raster_dimensions=(256, 256))
+spark_df.write.geotiff(outfile, crs='EPSG:4326', raster_dimensions=(256, 256))
 ```
 
 View it with `rasterio` to check the results:
@@ -82,6 +82,10 @@ with rasterio.open(outfile) as src:
 ```
 
 If there are many tile or projected raster columns in the DataFrame, the GeoTIFF writer will write each one as a separate band in the file. Each band in the output will be tagged the input column names for reference.
+
+```python, echo=False
+os.remove(outfile)
+```
 
 ## GeoTrellis Layers
 

--- a/pyrasterframes/src/main/python/tests/PyRasterFramesTests.py
+++ b/pyrasterframes/src/main/python/tests/PyRasterFramesTests.py
@@ -470,6 +470,13 @@ class RasterSource(TestEnvironment):
         print(path_count.toPandas())
         self.assertTrue(path_count.count() == 3)
 
+    def test_raster_source_reader_schemeless(self):
+        import os.path
+        path = os.path.join(self.resource_dir, "L8-B8-Robinson-IL.tiff")
+        self.assertTrue(not path.startswith('file://'))
+        df = self.spark.read.raster(path)
+        self.assertTrue(df.count() > 0)
+
     def test_raster_source_catalog_reader(self):
         import pandas as pd
 


### PR DESCRIPTION
Fix for #169  

The java.net.URI is a java object so possibly the URL.scheme can come back as `null` which was not always handled.

In the most important case in `RasterSource.IsDefaultGeoTiff.unapply` we made the faulty assumption that an empty scheme on a java.net.URI is the empty string `""` but never check for `null`.

Fixes the null check in that case.

This requires either no gdal support or config `rasterframes.prefer-gdal=false` to trigger it. Which is why it passed on circle but failed on travis. 

