### PR TITLE
WIP Fix Windows local GDAL read 

### DIFF
--- a/core/src/main/scala/org/locationtech/rasterframes/ref/GDALRasterSource.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/ref/GDALRasterSource.scala
@@ -40,12 +40,13 @@ case class GDALRasterSource(source: URI) extends RasterSource with URIRasterSour
       .replace("gdal+", "")
       .replace("gdal:/", "")
     // VSIPath doesn't like single slash "file:/path..."
+    // Local windows path regex used in VSIPath incorrectly removes only 1 slash of scheme
     val tweaked =
       if (cleaned.matches("^file:/[^/].*"))
-        cleaned.replace("file:", "")
+        cleaned.replaceFirst("^file:/", "file://")
       else cleaned
 
-    VLMRasterSource(tweaked)
+    VLMRasterSource(cleaned) // temporary work around to use `cleaned` not `tweaked`
   }
 
   protected def tiffInfo = SimpleRasterInfo.cache.get(source.toASCIIString, _ => SimpleRasterInfo(gdal))


### PR DESCRIPTION
Ensure our modifications to the incoming URI string work downstream in `VSIPath` for Windows local files. 