### PR TITLE
Add rf_mask unit test in python, import geomesa types with module import

### DIFF
--- a/pyrasterframes/src/main/python/docs/vector-data.pymd
+++ b/pyrasterframes/src/main/python/docs/vector-data.pymd
@@ -11,7 +11,6 @@ RasterFrames provides a variety of ways to work with spatial vector data (points
 ```python, setup, echo=False
 import pyrasterframes
 import pyrasterframes.rf_ipython
-import geomesa_pyspark.types
 import geopandas
 import folium
 spark = pyrasterframes.get_spark_session('local[2]')

--- a/pyrasterframes/src/main/python/pyrasterframes/__init__.py
+++ b/pyrasterframes/src/main/python/pyrasterframes/__init__.py
@@ -32,6 +32,7 @@ from pyspark.sql.column import _to_java_column
 from .rf_context import RFContext
 from .version import __version__
 from .rf_types import RasterFrameLayer, TileExploder, TileUDT, RasterSourceUDT
+import geomesa_pyspark.types  # enable vector integrations
 
 __all__ = ['RasterFrameLayer', 'TileExploder']
 


### PR DESCRIPTION
Just cause I was feeling paranoid about some other error I was encountering, I wrote this unit test. Also the import of geomesa_pyspark.types is an often enough encountered gotcha.

Signed-off-by: Jason T. Brown <jason@astraea.earth>