### PR TITLE
Applying pre-partitioning to DataSources.

### DIFF
--- a/experimental/src/main/scala/org/locationtech/rasterframes/experimental/datasource/CachedDatasetRelation.scala
+++ b/experimental/src/main/scala/org/locationtech/rasterframes/experimental/datasource/CachedDatasetRelation.scala
@@ -33,6 +33,8 @@ import org.locationtech.rasterframes.util._
  * @since 8/24/18
  */
 trait CachedDatasetRelation extends ResourceCacheSupport { self: BaseRelation ⇒
+  protected def defaultNumPartitions: Int =
+    sqlContext.sparkSession.sessionState.conf.numShufflePartitions
   protected def cacheFile: HadoopPath
   protected def constructDataset: Dataset[Row]
 

--- a/experimental/src/main/scala/org/locationtech/rasterframes/experimental/datasource/awspds/L8CatalogRelation.scala
+++ b/experimental/src/main/scala/org/locationtech/rasterframes/experimental/datasource/awspds/L8CatalogRelation.scala
@@ -68,7 +68,9 @@ case class L8CatalogRelation(sqlContext: SQLContext, sceneListPath: HadoopPath)
       .select(schema.map(f ⇒ col(f.name)): _*)
       .orderBy(ACQUISITION_DATE.name, PATH.name, ROW.name)
       .distinct() // The scene file contains duplicates.
-      .repartition(8, col(PATH.name), col(ROW.name))
+      .repartition(defaultNumPartitions, col(PATH.name), col(ROW.name))
+
+
   }
 }
 

--- a/experimental/src/main/scala/org/locationtech/rasterframes/experimental/datasource/awspds/MODISCatalogRelation.scala
+++ b/experimental/src/main/scala/org/locationtech/rasterframes/experimental/datasource/awspds/MODISCatalogRelation.scala
@@ -64,7 +64,7 @@ case class MODISCatalogRelation(sqlContext: SQLContext, sceneList: HadoopPath)
         $"${GID.name}") ++ bandCols: _*
       )
       .orderBy(ACQUISITION_DATE.name, GID.name)
-      .repartition(8, col(GRANULE_ID.name))
+      .repartition(defaultNumPartitions, col(GRANULE_ID.name))
   }
 }
 


### PR DESCRIPTION
Speeds up `experimental/it:test` from 527s to 194s.