### PR TITLE
Add libspatialindex and rtree to test environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ _defaults: &defaults
   environment:
     TERM: dumb
   docker:
-    - image: s22s/rasterframes-circleci:latest
+    - image: s22s/rasterframes-circleci:spatialindex
 
 _setenv: &setenv
   name: set CloudRepo credentials

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ _defaults: &defaults
   environment:
     TERM: dumb
   docker:
-    - image: s22s/rasterframes-circleci:spatialindex
+    - image: s22s/rasterframes-circleci:9b7682ef
 
 _setenv: &setenv
   name: set CloudRepo credentials

--- a/build/circleci/Dockerfile
+++ b/build/circleci/Dockerfile
@@ -2,6 +2,7 @@ FROM circleci/openjdk:8-jdk
 
 ENV OPENJPEG_VERSION 2.3.1
 ENV GDAL_VERSION 2.4.1
+ENV SPATIALINDEX_VERSION 1.9.3
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 
 # most of these libraries required for
@@ -74,3 +75,15 @@ RUN \
     sudo make install && \
     sudo ldconfig && \
     cd /tmp && sudo rm -Rf gdal*
+
+# Compile and install libspatialindex
+RUN \
+    cd /tmp && \
+    wget https://github.com/libspatialindex/libspatialindex/releases/download/${SPATIALINDEX_VERSION}/spatialindex-src-${SPATIALINDEX_VERSION}.tar.gz && \
+    tar -xf spatialindex-src-${SPATIALINDEX_VERSION}.tar.gz && \
+    cd spatialindex-src-${SPATIALINDEX_VERSION}/ && \
+    cmake  -DCMAKE_INSTALL_PREFIX=/usr/local/ && \
+    make && \
+    sudo make install && \
+    sudo ldconfig && \
+    cd /tmp && sudo rm -Rf spatialindex*

--- a/pyrasterframes/src/main/python/docs/sjoin.pymd
+++ b/pyrasterframes/src/main/python/docs/sjoin.pymd
@@ -1,0 +1,11 @@
+# Spatial Join
+
+```python
+import geopandas
+url = "http://d2ad6b4ur7yvpq.cloudfront.net/naturalearth-3.3.0/ne_110m_land.geojson"
+df = geopandas.read_file(url)
+df2 = geopandas.read_file(url)
+
+geopandas.sjoin(df, df2)
+```
+

--- a/pyrasterframes/src/main/python/requirements.txt
+++ b/pyrasterframes/src/main/python/requirements.txt
@@ -7,3 +7,4 @@ matplotlib<3.0.0  # no python 2.7 support after v2.x.x
 ipython==6.2.1
 rasterio>=1.0.0
 folium  # for documentation
+rtree # for geopandas spatial join etc


### PR DESCRIPTION
Enables use of geopandas spatial join in the docs and other parts of the build process, and for downstream apps. 