### PR TITLE
Docs/fix 252 viz extents

### DIFF
--- a/pyrasterframes/src/main/python/docs/raster-read.pymd
+++ b/pyrasterframes/src/main/python/docs/raster-read.pymd
@@ -39,12 +39,82 @@ rf.select(
 )
 ```
 
-You can also see that the single raster has been broken out into many arbitrary non-overlapping regions. Doing so takes advantage of parallel in-memory reads from the cloud hosted data source and allows Spark to work on manageable amounts of data per task. The following code fragment shows us how many subtiles were created from a single source image.
+You can also see that the single raster has been broken out into many rows containing arbitrary non-overlapping regions. Doing so takes advantage of parallel in-memory reads from the cloud hosted data source and allows Spark to work on manageable amounts of data per row. 
+The map below shows downsampled imagery with the bounds of the individual tiles.
 
-```python, count_by_uri
-counts = rf.groupby(rf.proj_raster_path).count()
-counts
+@@@ note 
+
+The image contains visible "seams" between the tile extents due to reprojection and downsampling used to create the image.
+The native imagery in the DataFrame does not contain any gaps in the source raster's coverage.
+
+@@@
+
+```python, folium_map_of_tile_extents, echo=False
+from pyrasterframes.rf_types import Extent
+import folium 
+import pyproj 
+from functools import partial
+from shapely.ops import transform as shtransform
+from shapely.geometry import box
+import geopandas
+import numpy 
+
+wm_crs = 'EPSG:3857'
+crs84 = 'urn:ogc:def:crs:OGC:1.3:CRS84'
+
+# Generate overview image
+wm_extent = rf.agg(
+                  rf_agg_reprojected_extent(rf_extent('proj_raster'), rf_crs('proj_raster'), wm_crs)
+                  ).first()[0]
+aoi = Extent.from_row(wm_extent)
+
+aspect = aoi.width / aoi.height
+ov_size = 1024
+ov = rf.agg(
+           rf_agg_overview_raster('proj_raster', int(ov_size * aspect), ov_size, aoi)
+           ).first()[0]
+
+#  Reproject the web mercator extent to WGS84
+project = partial(
+        pyproj.transform,
+        pyproj.Proj(wm_crs),
+        pyproj.Proj(crs84)
+    )
+crs84_extent = shtransform(project, box(*wm_extent))
+
+# Individual tile WGS84 extents in a dataframe
+tile_extents_df = rf.select(
+    st_reproject(
+        rf_geometry('proj_raster'),
+        rf_crs('proj_raster'),
+        rf_mk_crs('epsg:4326')
+    ).alias('geometry')
+).toPandas()
+
+ntiles = numpy.nanquantile(ov.cells, [0.03, 0.97])
+
+# use `filled` because folium doesn't know how to maskedArray
+a = numpy.clip(ov.cells.filled(0), ntiles[0], ntiles[1])
+ 
+m = folium.Map([crs84_extent.centroid.y, crs84_extent.centroid.x], 
+               zoom_start=9) \
+    .add_child(
+        folium.raster_layers.ImageOverlay(
+            a,
+            [[crs84_extent.bounds[1], crs84_extent.bounds[0]],
+             [crs84_extent.bounds[3], crs84_extent.bounds[2]]],
+            name='rf.proj_raster.tile'
+            )
+        ) \
+    .add_child(folium.GeoJson(
+        geopandas.GeoDataFrame(tile_extents_df, crs=crs84),
+        name='rf.proj_raster.extent',
+        style_function=lambda _: {'fillOpacity':0}
+    )) \
+    .add_child(folium.LayerControl(collapsed=False))
+m
 ```
+
 
 Let's select a single _tile_ and view it. The _tile_ preview image as well as the string representation provide some basic information about the _tile_: its dimensions as numbers of columns and rows and the cell type, or data type of all the cells in the _tile_. For more about cell types, refer to @ref:[this discussion](nodata-handling.md#cell-types).
 


### PR DESCRIPTION
Fix #252 

Stacks on top of #430

Add a folium map to the `raster-read` page showing tile overview and extents.

![image](https://user-images.githubusercontent.com/7798319/72081576-bd5e1c00-32cc-11ea-8cd0-03e37468273f.png)
