### PR TITLE
Fix for docs build failure on incorrect requirements.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,7 @@ workflows:
             branches:
               only:
                 - /feature\/.*docs.*/
+                - /fix\/.*docs.*/
                 - /docs\/.*/
 
   nightly:

--- a/pyrasterframes/src/main/python/requirements.txt
+++ b/pyrasterframes/src/main/python/requirements.txt
@@ -1,6 +1,6 @@
-ipython=6.2.1
-pyspark=2.4.4
-gdal=2.4.3
+ipython==6.2.1
+pyspark==2.4.4
+gdal==2.4.3
 numpy>=1.17.3,<2.0
 pandas>=0.25.3,<1.0
 shapely>=1.6.4,<1.7


### PR DESCRIPTION
Fix for:

```
#!/bin/bash -eo pipefail
pip3 install --quiet --user -r pyrasterframes/src/main/python/requirements.txt
ERROR: Invalid requirement: 'ipython=6.2.1' (from line 1 of pyrasterframes/src/main/python/requirements.txt)
Hint: = is not a valid operator. Did you mean == ?
```