### PR TITLE
Upgrade rasterframes-notebook container version of rtree.

### DIFF
--- a/rf-notebook/src/main/docker/requirements-nb.txt
+++ b/rf-notebook/src/main/docker/requirements-nb.txt
@@ -8,3 +8,4 @@ folium>=0.10.1,<0.11
 geopandas>=0.6.2,<0.7
 descartes>=1.1.0,<1.2
 pyarrow
+rtree>=0.9.2


### PR DESCRIPTION
Contains fixes for issues that were contaminating the `PATH` environment variable and causing the `spark-submit` to fail.