### PR TITLE
rf_tile_to_array_int returns Int, not double. Fix #473

### DIFF
--- a/core/src/main/scala/org/locationtech/rasterframes/functions/TileFunctions.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/functions/TileFunctions.scala
@@ -48,8 +48,8 @@ trait TileFunctions {
     TileToArrayDouble(col)
 
   /** Flattens Tile into an integer array. */
-  def rf_tile_to_array_int(col: Column): TypedColumn[Any, Array[Double]] =
-    TileToArrayDouble(col)
+  def rf_tile_to_array_int(col: Column): TypedColumn[Any, Array[Int]] =
+    TileToArrayInt(col)
 
   /** Convert array in `arrayCol` into a Tile of dimensions `cols` and `rows`*/
   def rf_array_to_tile(arrayCol: Column, cols: Int, rows: Int): TypedColumn[Any, Tile] = withTypedAlias("rf_array_to_tile")(

--- a/core/src/test/scala/org/locationtech/rasterframes/functions/TileFunctionsSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/functions/TileFunctionsSpec.scala
@@ -263,6 +263,10 @@ class TileFunctionsSpec extends TestEnvironment with RasterMatchers {
       val arrayDF = df.select(rf_tile_to_array_double($"tile").as[Array[Double]])
       arrayDF.first().sum should be(110.0 +- 0.0001)
 
+      val arrayDFInt = df.select(rf_tile_to_array_int($"tile"))
+      val arrayDFIntDType = arrayDFInt.dtypes
+      arrayDFIntDType(0)._2 should be("ArrayType(IntegerType,false)")
+
       checkDocs("rf_tile_to_array_int")
       checkDocs("rf_tile_to_array_double")
     }


### PR DESCRIPTION
rf_tile_to_array_int returns an array of Int.

Signed-off-by: Jean-Denis Giguère <jean-denis@anagraph.io>