### PR TITLE
Synchronize PEP 440 version with Maven/SBT

### DIFF
--- a/project/PythonBuildPlugin.scala
+++ b/project/PythonBuildPlugin.scala
@@ -114,7 +114,7 @@ object PythonBuildPlugin extends AutoPlugin {
       val wd = copyPySources.value
       val args = spaceDelimited("<args>").parsed
       val cmd = Seq(pythonCommand.value, "setup.py") ++ args
-      val ver = version.value
+      val ver = (Python / version).value
       s.log.info(s"Running '${cmd.mkString(" ")}' in '$wd'")
       val ec = Process(cmd, wd, "RASTERFRAMES_VERSION" -> ver).!
       if (ec != 0)

--- a/pyrasterframes/build.sbt
+++ b/pyrasterframes/build.sbt
@@ -26,14 +26,13 @@ pyNotebooks := {
 lazy val pySparkCmd = taskKey[Unit]("Create build and emit command to run in pyspark")
 pySparkCmd := {
   val s = streams.value
-  val jvm = assembly.value
   val py = (Python / packageBin).value
   val script = IO.createTemporaryDirectory / "pyrf_init.py"
   IO.write(script, """
 import pyrasterframes
 from pyrasterframes.rasterfunctions import *
 """)
-  val msg = s"PYTHONSTARTUP=$script pyspark --jars $jvm --py-files $py"
+  val msg = s"PYTHONSTARTUP=$script pyspark --py-files $py"
   s.log.debug(msg)
   println(msg)
 }

--- a/pyrasterframes/src/main/python/setup.py
+++ b/pyrasterframes/src/main/python/setup.py
@@ -20,18 +20,21 @@
 
 # Always prefer setuptools over distutils
 from setuptools import setup
-from os import path
+from os import path, environ, mkdir
 import sys
 from glob import glob
 from io import open
 import distutils.cmd
 
 try:
+    enver = environ.get('RASTERFRAMES_VERSION')
+    if enver is not None:
+        open('pyrasterframes/version.py', mode="w").write(f"__version__: str = '{enver}'\n")
     exec(open('pyrasterframes/version.py').read())  # executable python script contains __version__; credit pyspark
-except IOError:
-    print("Run setup via `sbt 'pySetup arg1 arg2'` to ensure correct access to all source files and binaries.")
+except IOError as e:
+    print(e)
+    print("Try running setup via `sbt 'pySetup arg1 arg2'` to ensure correct access to all source files and binaries.")
     sys.exit(-1)
-
 
 VERSION = __version__
 


### PR DESCRIPTION
Partial addressing of #459. pyrasterframes version numbers should be in sync with sbt, and PEP 440 compliant. At least for the cases we normally encounter.
