### PR TITLE
Fix failing doc build on Circle CI 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ orbs:
         steps:
           - run:
               name: Install requirements
-              command: pip3 install --progress-bar=off --user -r pyrasterframes/src/main/python/requirements.txt
+              command: pip install --progress-bar=off --user -r pyrasterframes/src/main/python/requirements.txt
 
   rasterframes:
     commands:


### PR DESCRIPTION
In local circleci command was able to get past the current job failure. Waiting for circle build to see if that's all we need.