### PR TITLE
Updates for clean CI build

### DIFF
--- a/core/src/test/scala/org/locationtech/rasterframes/TestData.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/TestData.scala
@@ -141,14 +141,16 @@ trait TestData {
     rf.toTileLayerRDD(rf.tileColumns.head).left.get
   }
 
-  private val baseCOG = "https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/149/039/LC08_L1TP_149039_20170411_20170415_01_T1/LC08_L1TP_149039_20170411_20170415_01_T1_%s.TIF"
-  lazy val remoteCOGSingleband1: URI = URI.create(baseCOG.format("B1"))
-  lazy val remoteCOGSingleband2: URI = URI.create(baseCOG.format("B2"))
+  // Check the URL exists as of 2020-09-30; strictly these are not COGs because they do not have internal overviews
+  private def remoteCOGSingleBand(b: Int) = URI.create(s"https://landsat-pds.s3.us-west-2.amazonaws.com/c1/L8/017/029/LC08_L1TP_017029_20200422_20200509_01_T1/LC08_L1TP_017029_20200422_20200509_01_T1_B${b}.TIF")
+  lazy val remoteCOGSingleband1: URI = remoteCOGSingleBand(1)
+  lazy val remoteCOGSingleband2: URI = remoteCOGSingleBand(2)
 
-  lazy val remoteCOGMultiband: URI =  URI.create("https://s3-us-west-2.amazonaws.com/radiant-nasa-iserv/2014/02/14/IP0201402141023382027S03100E/IP0201402141023382027S03100E-COG.tif")
+  // a public 4 band COG TIF
+  lazy val remoteCOGMultiband: URI = URI.create("https://s22s-rasterframes-integration-tests.s3.amazonaws.com/m_4411708_ne_11_1_20141005.cog.tif")
 
   lazy val remoteMODIS: URI = URI.create("https://modis-pds.s3.amazonaws.com/MCD43A4.006/31/11/2017158/MCD43A4.A2017158.h31v11.006.2017171203421_B01.TIF")
-  lazy val remoteL8: URI = URI.create("https://s3-us-west-2.amazonaws.com/landsat-pds/c1/L8/017/033/LC08_L1TP_017033_20181010_20181030_01_T1/LC08_L1TP_017033_20181010_20181030_01_T1_B4.TIF")
+  lazy val remoteL8: URI = URI.create("https://landsat-pds.s3.amazonaws.com/c1/L8/017/033/LC08_L1TP_017033_20181010_20181030_01_T1/LC08_L1TP_017033_20181010_20181030_01_T1_B4.TIF")
   lazy val remoteHttpMrfPath: URI = URI.create("https://s3.amazonaws.com/s22s-rasterframes-integration-tests/m_3607526_sw_18_1_20160708.mrf")
   lazy val remoteS3MrfPath: URI = URI.create("s3://naip-analytic/va/2016/100cm/rgbir/37077/m_3707764_sw_18_1_20160708.mrf")
 

--- a/core/src/test/scala/org/locationtech/rasterframes/ref/RasterSourceSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/ref/RasterSourceSpec.scala
@@ -102,7 +102,7 @@ class RasterSourceSpec extends TestEnvironment with TestData {
     }
     it("should read sub-tile") {
       withClue("remoteCOGSingleband") {
-        val src = RFRasterSource(remoteCOGSingleband1)
+        val src = RFRasterSource(remoteMODIS)
         val raster = src.read(sub(src.extent))
         assert(raster.size > 0 && raster.size < src.size)
       }


### PR DESCRIPTION
`TestData.remoteCOGMultiband` was on an S3 bucket that has been removed; added new public multiband COG to own bucket

Some dependency in python has changed causing a conflict between `jupyter_client` and `nbclient`

```
pkg_resources.ContextualVersionConflict: (jupyter-client 5.3.5 (/home/circleci/repo/pyrasterframes/target/python/.eggs/jupyter_client-5.3.5-py3.7.egg), Requirement.parse('jupyter-client>=6.1.5'), {'nbclient'})
```
