### PR TITLE
Set spark master with spark.task.maxFailures in test

### DIFF
--- a/core/src/test/scala/org/locationtech/rasterframes/TestEnvironment.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/TestEnvironment.scala
@@ -50,7 +50,8 @@ trait TestEnvironment extends FunSpec
     outputDir
   }
 
-  def sparkMaster: String = "local[*]"
+  // allow 2 retries, should stabilize CI builds. https://spark.apache.org/docs/2.4.7/submitting-applications.html#master-urls
+  def sparkMaster: String = "local[*, 2]"
 
   def additionalConf = new SparkConf(false)
 

--- a/pyrasterframes/src/main/python/tests/__init__.py
+++ b/pyrasterframes/src/main/python/tests/__init__.py
@@ -61,6 +61,7 @@ def resource_dir():
 
 def spark_test_session():
     spark = create_rf_spark_session(**{
+        'spark.master': 'local[*, 2]',
         'spark.ui.enabled': 'false',
         'spark.app.name': app_name
     })


### PR DESCRIPTION
This should reduce spurious failures on CI builds

Signed-off-by: Jason T. Brown <jason@astraea.earth>