### PR TITLE
Slippy map writing support.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -176,7 +176,7 @@ lazy val docs = project
     Compile / paradoxMaterialTheme ~= { _
       .withRepository(uri("https://github.com/locationtech/rasterframes"))
       .withCustomStylesheet("assets/custom.css")
-      .withCopyright("""&copy; 2017-2019 <a href="https://astraea.earth">Astraea</a>, Inc. All rights reserved.""")
+      .withCopyright("""&copy; 2017-2021 <a href="https://astraea.earth">Astraea</a>, Inc. All rights reserved.""")
       .withLogo("assets/images/RF-R.svg")
       .withFavicon("assets/images/RasterFrames_32x32.ico")
       .withColor("blue-grey", "light-blue")

--- a/datasource/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
+++ b/datasource/src/main/resources/META-INF/services/org.apache.spark.sql.sources.DataSourceRegister
@@ -5,3 +5,4 @@ org.locationtech.rasterframes.datasource.raster.RasterSourceDataSource
 org.locationtech.rasterframes.datasource.geojson.GeoJsonDataSource
 org.locationtech.rasterframes.datasource.stac.api.StacApiDataSource
 org.locationtech.rasterframes.datasource.tiles.TilesDataSource
+org.locationtech.rasterframes.datasource.slippy.SlippyDataSource

--- a/datasource/src/main/resources/slippy.html
+++ b/datasource/src/main/resources/slippy.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<!--
+  ~ This software is licensed under the Apache 2 license, quoted below.
+  ~
+  ~ Copyright 2021 Astraea. Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License"); you may not
+  ~ use this file except in compliance with the License. You may obtain a copy of
+  ~ the License at
+  ~
+  ~     [http://www.apache.org/licenses/LICENSE-2.0]
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+  ~ WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+  ~ License for the specific language governing permissions and limitations under
+  ~ the License.
+  ~
+  ~
+  -->
+
+<html lang="en">
+<head>
+    <title>RasterFrames Rendering</title>
+    <meta charset="utf-8" />
+   	<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta property="eai:center" content="(${viewLat},${viewLon})"/>
+    <meta property="eai:maxZoom" content="${maxNativeZoom}"/>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" integrity="sha512-Rksm5RenBEKSKFjgI3a41vrjkw4EVPlJ3+OiI65vTjIdo9brlAacEuKOiQ5OFh7cOI1bkDwLqdLw3Zg0cRJAAQ==" crossorigin=""/>
+    <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js" integrity="sha512-/Nsx9X4HebavoBvEBuyp3I7od5tA0UzAxs+j83KgC8PU0kgB4XiK4Lfe4y4cgBtaRJQEIFCW+oC506aPT2L1zw==" crossorigin=""></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.css" />
+    <script src="https://unpkg.com/leaflet-control-geocoder/dist/Control.Geocoder.js"></script>
+    <style>
+        #mapid {
+            position: absolute;
+            top: 10px;
+            bottom: 10px;
+            left: 10px;
+            right: 10px;
+        }
+    </style>
+</head>
+<body>
+
+<div id="mapid"></div>
+
+<script>
+
+    var map = L.map('mapid')
+        .setView([${viewLat}, ${viewLon}], ${maxNativeZoom});
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'}).addTo(map);
+
+   	L.tileLayer(
+   	    '{z}/{x}/{y}.png', {
+   	        maxZoom: 18,
+   	        maxNativeZoom: ${maxNativeZoom}
+        }
+    ).addTo(map);
+
+    L.control.scale().addTo(map);
+
+    L.Control.geocoder().addTo(map);
+
+   	var popup = L.popup();
+
+   	function showPos(e) {
+   		popup
+   			.setLatLng(e.latlng)
+   			.setContent(e.latlng.toString())
+   			.openOn(map);
+   	}
+
+   	map.on('click', showPos);
+</script>
+</body>
+</html>

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/slippy/DataFrameSlippyExport.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/slippy/DataFrameSlippyExport.scala
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2020 Astraea, Inc. All right reserved.
+ */
+
+package org.locationtech.rasterframes.datasource.slippy
+
+import geotrellis.layer.{SpatialKey, TileLayerMetadata, ZoomedLayoutScheme}
+import geotrellis.proj4.{LatLng, WebMercator}
+import geotrellis.raster._
+import geotrellis.raster.render.ColorRamp
+import geotrellis.raster.resample.Bilinear
+import geotrellis.spark._
+import geotrellis.spark.pyramid.Pyramid
+import geotrellis.spark.store.slippy.HadoopSlippyTileWriter
+import geotrellis.vector.reproject.Implicits._
+import org.apache.commons.text.StringSubstitutor
+import org.apache.hadoop.fs.{FileSystem, Path}
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.locationtech.rasterframes.encoders.StandardEncoders
+import org.locationtech.rasterframes.expressions.aggregates.ProjectedLayerMetadataAggregate
+import org.locationtech.rasterframes.util.withResource
+import org.locationtech.rasterframes.{rf_agg_approx_histogram, _}
+import org.locationtech.rasterframes.datasource._
+
+import java.io.PrintStream
+import java.net.URI
+import java.nio.file.Paths
+import scala.io.Source
+import RenderingProfiles._
+import org.locationtech.rasterframes.datasource.slippy.RenderingModes.{RenderingMode, Uniform}
+
+object DataFrameSlippyExport extends StandardEncoders {
+  val destCRS = WebMercator
+
+  /**
+   * Export tiles as a slippy map.
+   * NB: Temporal components are ignored blindly.
+   *
+   * @param dest    URI for Hadoop supported storage endpoint (e.g. 'file://', 'hdfs://', etc.).
+   * @param profile Rendering profile
+   */
+  def writeSlippyTiles(df: DataFrame, dest: URI, profile: Profile): SlippyResult = {
+
+    val spark = df.sparkSession
+    implicit val sc = spark.sparkContext
+
+    val outputPath: String = dest.toASCIIString
+
+    require(
+      df.tileColumns.length >= profile.expectedBands, // TODO: Do we want to allow this greater than case? Warn the user?
+      s"Selected rendering mode '${profile}' expected ${profile.expectedBands} bands.")
+
+    // select only the tile columns given by user and crs, extent columns which are fallback if first `column` is not a PRT
+    val SpatialComponents(crs, extent, dims, cellType) = projectSpatialComponents(df)
+      .getOrElse(
+        throw new IllegalArgumentException("Provided dataframe did not have an Extent and/or CRS"))
+
+    val tlm: TileLayerMetadata[SpatialKey] =
+      df.select(
+          ProjectedLayerMetadataAggregate(
+            destCRS,
+            extent,
+            crs,
+            cellType,
+            dims
+          )
+        )
+        .first()
+
+    val rfLayer = df
+      .toLayer(tlm)
+      // TODO: this should be fixed in RasterFrames
+      .na
+      .drop()
+      .persist()
+      .asInstanceOf[RasterFrameLayer]
+
+    val inputRDD: MultibandTileLayerRDD[SpatialKey] =
+      rfLayer.toMultibandTileLayerRDD match {
+        case Left(spatial) => spatial
+        case Right(_) =>
+          throw new NotImplementedError(
+            "Dataframes with multiple temporal values are not yet supported.")
+      }
+
+    val tileColumns = rfLayer.tileColumns
+
+    val rp = profile match {
+      case up: UniformColorRampProfile =>
+        val hist = rfLayer
+          .select(rf_agg_approx_histogram(tileColumns.head))
+          .first()
+        up.toResolvedProfile(hist)
+      case up: UniformRGBColorProfile =>
+        require(tileColumns.length >= 3)
+        val stats = rfLayer
+          .select(
+            rf_agg_stats(tileColumns(0)),
+            rf_agg_stats(tileColumns(1)),
+            rf_agg_stats(tileColumns(2)))
+          .first()
+        up.toResolvedProfile(stats._1, stats._2, stats._3)
+      case o => o
+    }
+
+    val layoutScheme = ZoomedLayoutScheme(WebMercator, tileSize = 256)
+
+    val (zoom, reprojected) = inputRDD.reproject(WebMercator, layoutScheme, Bilinear)
+    val renderer = (_: SpatialKey, tile: MultibandTile) => rp.render(tile).bytes
+    val writer = new HadoopSlippyTileWriter[MultibandTile](outputPath, "png")(renderer)
+
+    // Pyramiding up the zoom levels, write our tiles out to the local file system.
+    Pyramid.upLevels(reprojected, layoutScheme, zoom, Bilinear) { (rdd, z) =>
+      writer.write(z, rdd)
+    }
+
+    rfLayer.unpersist()
+
+    val center = reprojected.metadata.extent.center
+      .reproject(WebMercator, LatLng)
+
+    SlippyResult(dest, center.getY, center.getX, zoom)
+  }
+
+  def writeSlippyTiles(df: DataFrame, dest: URI, renderingMode: RenderingMode): SlippyResult = {
+
+    val profile = (df.tileColumns.length, renderingMode) match {
+      case (1, Uniform) => UniformColorRampProfile(greyscale)
+      case (_, Uniform) => UniformRGBColorProfile()
+      case (1, _) => ColorRampProfile(greyscale)
+      case _ => RGBColorProfile()
+    }
+    writeSlippyTiles(df, dest, profile)
+  }
+
+  def writeSlippyTiles(df: DataFrame, dest: URI, colorRamp: ColorRamp, renderingMode: RenderingMode): SlippyResult = {
+    val profile = renderingMode match {
+      case Uniform ⇒ UniformColorRampProfile(colorRamp)
+      case _ ⇒ ColorRampProfile(colorRamp)
+    }
+    writeSlippyTiles(df, dest, profile)
+  }
+
+  case class SlippyResult(dest: URI, centerLat: Double, centerLon: Double, maxZoom: Int) {
+    // for python interop
+    def outputUrl(): String = dest.toASCIIString
+
+    def writeHtml(spark: SparkSession): Unit = {
+      import java.util.{HashMap => JMap}
+
+      val subst = new StringSubstitutor(new JMap[String, String]() {
+        put("maxNativeZoom", maxZoom.toString)
+        put("id", Paths.get(dest.getPath).getFileName.toString)
+        put("viewLat", centerLat.toString)
+        put("viewLon", centerLon.toString)
+      })
+
+      val rawLines = Source.fromInputStream(getClass.getResourceAsStream("/slippy.html")).getLines()
+
+      val fs = FileSystem.get(dest, spark.sparkContext.hadoopConfiguration)
+
+      withResource(fs.create(new Path(new Path(dest), "index.html"), true)) { hout =>
+        val out = new PrintStream(hout, true, "UTF-8")
+        for (line <- rawLines) {
+          out.println(subst.replace(line))
+        }
+      }
+    }
+  }
+}

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/slippy/RenderingModes.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/slippy/RenderingModes.scala
@@ -1,0 +1,35 @@
+/*
+ * This software is licensed under the Apache 2 license, quoted below.
+ *
+ * Copyright (c) 2021. Astraea, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     [http://www.apache.org/licenses/LICENSE-2.0]
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package org.locationtech.rasterframes.datasource.slippy
+
+object RenderingModes {
+  // used as Enumeration of options in SlippyDataSource interpretation of string options.
+  sealed trait RenderingMode
+  case object Fast extends RenderingMode
+  case object Uniform extends RenderingMode
+
+  def renderingModeFromString(rendering_mode_name: String): RenderingMode =
+    rendering_mode_name.toLowerCase() match {
+      case "uniform" | "histogram" ⇒ Uniform
+      case _ ⇒ Fast
+    }
+
+}

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/slippy/RenderingProfiles.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/slippy/RenderingProfiles.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2020 Astraea, Inc. All right reserved.
+ */
+
+package org.locationtech.rasterframes.datasource.slippy
+
+import geotrellis.raster._
+import geotrellis.raster.render.{ColorRamp, ColorRamps, Png}
+import org.locationtech.rasterframes.stats.{CellHistogram, CellStatistics}
+
+import scala.util.Try
+
+
+private[slippy]
+object RenderingProfiles {
+  /** Base type for Rendering profiles. */
+  trait Profile {
+    /** Expected number of bands. */
+    val expectedBands: Int
+    /** Go from tile to PNG. */
+    def render(tile: MultibandTile): Png
+  }
+
+  val greyscale = ColorRamps.greyscale(256)
+
+  case class ColorMapProfile(cmap: ColorMap) extends Profile {
+    val expectedBands: Int = 1
+    override def render(tile: MultibandTile): Png = {
+      require(tile.bandCount >= expectedBands, "Expected at least one band.")
+      tile.band(0).renderPng(cmap)
+    }
+  }
+
+  case class ColorRampProfile(ramp: ColorRamp, breaks: Int = 256) extends Profile {
+    val expectedBands: Int = 1
+    // Are there other ways to use the other bands?
+    override def render(tile: MultibandTile): Png = {
+      require(tile.bandCount >= expectedBands, s"Need at least 1 band")
+      tile.band(0).renderPng(ramp)
+    }
+  }
+
+  case class UniformColorRampProfile(ramp: ColorRamp, breaks: Int = 256) extends Profile {
+    val expectedBands: Int = 1
+    def toResolvedProfile(histo: CellHistogram): Profile =
+      ColorMapProfile(ramp.toColorMap(histo.quantileBreaks(breaks)))
+    override def render(tile: MultibandTile): Png = {
+      // This hack around partially specifying a color
+      // profile is likely anathema to many, but since this
+      // class is package private and the semantics should only affect
+      // sibling classes, I think it's an OK compromise for how.
+      throw new IllegalStateException("Use requires call to `toColorMapProfile`")
+    }
+  }
+
+  case class RGBColorProfile() extends Profile {
+    val expectedBands: Int = 3
+    override def render(tile: MultibandTile): Png = {
+      val scaled = tile
+        .mapBands((_, t) => Try(t.rescale(0, 255)).getOrElse(t))
+      scaled.renderPng()
+    }
+  }
+
+  case class UniformRGBColorProfile(private val stats: Seq[CellStatistics] = Seq.empty) extends Profile {
+    /** Expected number of bands. */
+    override val expectedBands: Int = 3
+
+    def toResolvedProfile(red: CellStatistics, green: CellStatistics, blue: CellStatistics) = {
+      UniformRGBColorProfile(Seq(red, green, blue))
+    }
+
+    /** Go from tile to PNG. */
+    override def render(tile: MultibandTile): Png = {
+      if (stats.isEmpty) {
+        // See note in UniformColorRampProfile above
+        throw new IllegalStateException("Use requires call to `toRGBColorProfile`")
+      }
+      else {
+        // Hacky but fast multiband normalization.
+        val scaled = tile.bands.zip(stats).map { case (t, s) =>
+          val min = s.mean - 5 * s.stddev
+          val max = s.mean + 5 * s.stddev
+          t.normalize(min, max, 0, 255).convert(UByteConstantNoDataCellType)
+        }
+
+        // Couldn't get this to work
+//        // If one of the channels is no-data, make all of them no-data
+//        val mask = scaled.map(Defined.apply).reduce(And(_, _))
+//        val masked = scaled.map(_.localMask(mask, 0, ubyteNODATA))
+        MultibandTile(scaled).renderPng()
+      }
+    }
+  }
+}

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/slippy/SlippyDataSource.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/slippy/SlippyDataSource.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020 Astraea, Inc. All right reserved.
+ */
+
+package org.locationtech.rasterframes.datasource.slippy
+
+import geotrellis.raster.render.ColorRamp
+import org.apache.spark.sql.sources.{BaseRelation, CreatableRelationProvider, DataSourceRegister}
+import org.apache.spark.sql.{DataFrame, SQLContext, SaveMode}
+import org.locationtech.rasterframes.util.ColorRampNames
+import DataFrameSlippyExport._
+import org.locationtech.rasterframes.datasource
+import org.locationtech.rasterframes.datasource.slippy.RenderingModes.{Fast, RenderingMode, Uniform}
+
+import java.net.URI
+
+class SlippyDataSource extends DataSourceRegister with CreatableRelationProvider {
+  import SlippyDataSource._
+  override def shortName(): String = SHORT_NAME
+  override def createRelation(sqlContext: SQLContext, mode: SaveMode, parameters: Map[String, String], data: DataFrame): BaseRelation = {
+    val pathURI = parameters.path.getOrElse(throw new IllegalArgumentException("Valid URI 'path' parameter required."))
+
+    // TODO: How to make use of these? Looked through Spark sourcer and it's not clear
+    // how one properly implements these so they work in a distributed context.
+    mode match {
+      case SaveMode.Append => ()
+      case SaveMode.Overwrite => ()
+      case SaveMode.ErrorIfExists =>()
+      case SaveMode.Ignore => ()
+    }
+    val info = parameters.colorRamp match {
+      case Some(cr) =>
+        writeSlippyTiles(data, pathURI, cr, parameters.renderingMode)
+      case _ =>
+        writeSlippyTiles(data, pathURI, parameters.renderingMode)
+    }
+
+    if (parameters.withHTML)
+      info.writeHtml(sqlContext.sparkSession)
+
+    // The current function is called by `org.apache.spark.sql.execution.datasources.SaveIntoDataSourceCommand`, which
+    // ignores the return value. It in turn returns `Seq.empty[Row]`... ¯\_(ツ)_/¯
+    null
+  }
+}
+
+
+object SlippyDataSource {
+  final val SHORT_NAME = "slippy"
+  final val PATH_PARAM = "path"
+  final val COLOR_RAMP_PARAM = "colorramp"
+  final val HTML_PARAM = "html"
+  final val RENDERING_MODE_PARAM = "renderingmode"
+
+  implicit class SlippyDictAccessors(val parameters: Map[String, String]) extends AnyVal {
+    def path: Option[URI] = datasource.uriParam(PATH_PARAM, parameters)
+    def colorRamp: Option[ColorRamp] = parameters.get(COLOR_RAMP_PARAM).flatMap {
+      case ColorRampNames(ramp) => Some(ramp)
+      case _ => None
+    }
+    def renderingMode: RenderingMode = parameters.get(RENDERING_MODE_PARAM).map(_.toLowerCase()) match {
+      case Some("uniform") | Some("histogram") ⇒ Uniform
+      case _ ⇒ Fast
+    }
+    def withHTML: Boolean = parameters.get(HTML_PARAM).exists(_.toBoolean)
+  }
+}

--- a/datasource/src/main/scala/org/locationtech/rasterframes/datasource/slippy/package.scala
+++ b/datasource/src/main/scala/org/locationtech/rasterframes/datasource/slippy/package.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2020 Astraea, Inc. All right reserved.
+ */
+
+package org.locationtech.rasterframes.datasource
+
+import org.apache.spark.sql.DataFrameWriter
+import org.locationtech.rasterframes.util.ColorRampNames
+import shapeless.tag.@@
+
+package object slippy {
+    trait SlippyDataFrameWriterTag
+
+    type SlippyDataFrameWriter[T] = DataFrameWriter[T] @@ SlippyDataFrameWriterTag
+
+    /** Adds `slippy` format specifier to `DataFrameWriter`. */
+    implicit class DataFrameWriterHasSlippyFormat[T](val reader: DataFrameWriter[T]) {
+      def slippy: SlippyDataFrameWriter[T] =
+        shapeless.tag[SlippyDataFrameWriterTag][DataFrameWriter[T]](
+          reader.format(SlippyDataSource.SHORT_NAME))
+    }
+
+    /** Adds option methods relevant to SlippyDataSource. */
+    implicit class SlippyDataFrameWriterHasOptions[T](val writer: SlippyDataFrameWriter[T]) {
+      private def checkCM(colorRampName: String): Unit =
+        require(ColorRampNames.unapply(colorRampName).isDefined,
+          s"'$colorRampName' does was not found in ${ColorRampNames().mkString(",")}'")
+
+      def withColorRamp(colorRampName: String): SlippyDataFrameWriter[T] = {
+        checkCM(colorRampName)
+        shapeless.tag[SlippyDataFrameWriterTag][DataFrameWriter[T]](
+          writer.option(SlippyDataSource.COLOR_RAMP_PARAM, colorRampName)
+        )
+      }
+
+      def withUniformColor: SlippyDataFrameWriter[T] = {
+        shapeless.tag[SlippyDataFrameWriterTag][DataFrameWriter[T]](
+          writer.option(SlippyDataSource.RENDERING_MODE_PARAM, RenderingModes.Uniform.toString)
+        )
+      }
+
+      def withHTML: SlippyDataFrameWriter[T] = {
+        shapeless.tag[SlippyDataFrameWriterTag][DataFrameWriter[T]](
+          writer.option(SlippyDataSource.HTML_PARAM, true.toString)
+        )
+      }
+    }
+}

--- a/datasource/src/test/scala/org/locationtech/rasterframes/datasource/slippy/SlippyDataSourceSpec.scala
+++ b/datasource/src/test/scala/org/locationtech/rasterframes/datasource/slippy/SlippyDataSourceSpec.scala
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2020 Astraea, Inc. All right reserved.
+ */
+
+package org.locationtech.rasterframes.datasource.slippy
+
+import better.files._
+import org.locationtech.rasterframes._
+import org.locationtech.rasterframes.datasource.raster._
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+
+class SlippyDataSourceSpec extends TestEnvironment with TestData with BeforeAndAfterAll {
+  import spark.implicits._
+
+  val baseDir = File("target") / "slippy"
+
+  override def beforeAll() = baseDir.delete(swallowIOExceptions = true)
+
+  def countFiles(dir: File, extension: String): Int = {
+    dir.list(f => f.isRegularFile && f.name.endsWith(extension)).length
+  }
+
+  // When running in the IDE on MacOS, launch viewer pages for visual evaluation.
+  def view(dir: File): Unit = {
+    def isIntelliJ = sys.props.get("sun.java.command").exists(_.contains("jetbrains"))
+    if (isIntelliJ && System.getProperty("os.name").contains("Mac")) {
+      import scala.sys.process._
+      val openCommand = s"open ${(dir / "index.html").canonicalPath}"
+      openCommand.!
+    }
+  }
+
+  def tileFilesCount(dir: File): Long = {
+    val r = countFiles(dir, ".png")
+    println(dir, r)
+    r
+  }
+
+  def mkOutdir(prefix: String) = {
+    val resultsDir = baseDir.createDirectories()
+    File.newTemporaryDirectory(prefix, Some(resultsDir))
+  }
+
+  val l8RGBPath = Resource.getUrl("LC08_RGB_Norfolk_COG.tiff").toURI
+
+  describe("Slippy writing") {
+    val rf = spark.read.raster
+      .from(Seq(l8RGBPath))
+      .withLazyTiles(false)
+      .withTileDimensions(128, 128)
+      .withBandIndexes(0, 1, 2)
+      .load()
+      .withColumnRenamed("proj_raster_b0", "red")
+      .withColumnRenamed("proj_raster_b1", "green")
+      .withColumnRenamed("proj_raster_b2", "blue")
+      .cache()
+
+    it("should write a singleband") {
+      val dir = mkOutdir("single-")
+      rf.select($"red")
+        .write.slippy.withHTML.save(dir.toString)
+      tileFilesCount(dir) should be (155L)
+      view(dir)
+    }
+
+    it("should write with non-uniform coloring") {
+      val dir = mkOutdir("quick-")
+      rf.select($"green")
+        .write.slippy.withColorRamp("BlueToOrange")
+        .withHTML.save(dir.toString)
+
+      tileFilesCount(dir) should be (155L)
+      view(dir)
+    }
+
+    it("should write with uniform coloring") {
+      val dir = mkOutdir("uniform-")
+      rf.select($"green")
+        .write.slippy
+        .withColorRamp("Viridis")
+        .withUniformColor
+        .withHTML.save(dir.toString)
+
+      tileFilesCount(dir) should be (155L)
+      view(dir)
+    }
+    it("should write greyscale") {
+      val dir = mkOutdir("relation-hist-noramp-")
+      rf.select($"green")
+        .write.slippy
+        .withUniformColor
+        .withHTML
+        .save(dir.toString)
+
+      tileFilesCount(dir) should be (155L)
+      view(dir)
+    }
+
+    it("Should write colour composite") {
+      val dir = mkOutdir("color-")
+      rf.write.slippy
+        .withUniformColor
+        .withHTML
+        .save(dir.toString())
+      tileFilesCount(dir) should be (155L)
+      view(dir)
+    }
+
+    it("should construct map on a file in the wild") {
+      val modisUrl = "s3://astraea-opendata/MCD43A4.006/27/05/2020161/MCD43A4.A2020161.h27v05.006.2020170060718_B01.TIF"
+      val modisRf = spark.read.raster.from(Seq(modisUrl))
+        .withLazyTiles(false)
+        .load()
+      val dir = mkOutdir("modis-")
+      modisRf.write.slippy
+        .withUniformColor
+        .withHTML
+        .save(dir.toString())
+      tileFilesCount(dir) should be (210L)
+      view(dir)
+    }
+
+    ignore("should write non-homogenous cell types") {
+      val dir = mkOutdir(s"mixed-celltypes-")
+      noException should be thrownBy {
+        rf.select(rf_log($"red"), $"green", $"blue")
+          .write.slippy.withHTML.save(dir.toString)
+      }
+
+      tileFilesCount(dir) should be (151L)
+      view(dir)
+    }
+  }
+}
+
+// Runner to support profiling.
+//object SlippyDataSourceSpec {
+//  def main(args: Array[String]): Unit = {
+//    import org.scalatest._
+//    run(new SlippyDataSourceSpec, testName = "Should write colour composite")
+//  }
+//}

--- a/datasource/src/test/scala/org/locationtech/rasterframes/datasource/slippy/SlippyDataSourceSpec.scala
+++ b/datasource/src/test/scala/org/locationtech/rasterframes/datasource/slippy/SlippyDataSourceSpec.scala
@@ -107,7 +107,7 @@ class SlippyDataSourceSpec extends TestEnvironment with TestData with BeforeAndA
     }
 
     it("should construct map on a file in the wild") {
-      val modisUrl = "s3://astraea-opendata/MCD43A4.006/27/05/2020161/MCD43A4.A2020161.h27v05.006.2020170060718_B01.TIF"
+      val modisUrl = "s3://modis-pds/MCD43A4.006/27/05/2020161/MCD43A4.A2020161.h27v05.006.2020170060718_B01.TIF"
       val modisRf = spark.read.raster.from(Seq(modisUrl))
         .withLazyTiles(false)
         .load()

--- a/datasource/src/test/scala/org/locationtech/rasterframes/datasource/slippy/SlippyDataSourceSpec.scala
+++ b/datasource/src/test/scala/org/locationtech/rasterframes/datasource/slippy/SlippyDataSourceSpec.scala
@@ -107,7 +107,7 @@ class SlippyDataSourceSpec extends TestEnvironment with TestData with BeforeAndA
     }
 
     it("should construct map on a file in the wild") {
-      val modisUrl = "s3://modis-pds/MCD43A4.006/27/05/2020161/MCD43A4.A2020161.h27v05.006.2020170060718_B01.TIF"
+      val modisUrl = "https://modis-pds.s3.us-west-2.amazonaws.com/MCD43A4.006/27/05/2020161/MCD43A4.A2020161.h27v05.006.2020170060718_B01.TIF"
       val modisRf = spark.read.raster.from(Seq(modisUrl))
         .withLazyTiles(false)
         .load()


### PR DESCRIPTION
Requires #571 

Adds ability to write out a RasterFrame as a slippy map for visualization. Provides color compositing and rendering options for tweaking results.