### PR TITLE
Fix UDTs registration ordering

### DIFF
--- a/core/src/main/scala/org/locationtech/rasterframes/encoders/StandardEncoders.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/encoders/StandardEncoders.scala
@@ -33,6 +33,8 @@ import org.locationtech.geomesa.spark.jts.encoders.SpatialEncoders
 import org.locationtech.rasterframes.model.{CellContext, LongExtent, TileContext, TileDataContext}
 import frameless.TypedEncoder
 import geotrellis.raster.mapalgebra.focal.{Kernel, Neighborhood, TargetCell}
+import org.locationtech.rasterframes.ref.RFRasterSource
+import org.locationtech.rasterframes.tiles.ProjectedRasterTile
 
 import java.net.URI
 import java.sql.Timestamp
@@ -78,6 +80,11 @@ trait StandardEncoders extends SpatialEncoders with TypedEncoders {
 
   implicit lazy val tileEncoder: ExpressionEncoder[Tile] = typedExpressionEncoder
   implicit def rasterEncoder[T <: CellGrid[Int]: TypedEncoder]: ExpressionEncoder[Raster[T]] = typedExpressionEncoder[Raster[T]]
+
+  // Intentionally not implicit, defined as implicit in the ProjectedRasterTile companion object
+  lazy val projectedRasterTileEncoder: ExpressionEncoder[ProjectedRasterTile] = typedExpressionEncoder
+  // Intentionally not implicit, defined as implicit in the RFRasterSource companion object
+  lazy val rfRasterSourceEncoder: ExpressionEncoder[RFRasterSource] = typedExpressionEncoder
 }
 
 object StandardEncoders extends StandardEncoders

--- a/core/src/main/scala/org/locationtech/rasterframes/encoders/StandardEncoders.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/encoders/StandardEncoders.scala
@@ -47,7 +47,6 @@ trait StandardEncoders extends SpatialEncoders with TypedEncoders {
   implicit def optionalEncoder[T: TypedEncoder]: ExpressionEncoder[Option[T]] = typedExpressionEncoder[Option[T]]
 
   implicit lazy val strMapEncoder: ExpressionEncoder[Map[String, String]] = ExpressionEncoder()
-  implicit lazy val crsExpressionEncoder: ExpressionEncoder[CRS] = ExpressionEncoder()
   implicit lazy val projectedExtentEncoder: ExpressionEncoder[ProjectedExtent] = ExpressionEncoder()
   implicit lazy val temporalProjectedExtentEncoder: ExpressionEncoder[TemporalProjectedExtent] = ExpressionEncoder()
   implicit lazy val timestampEncoder: ExpressionEncoder[Timestamp] = ExpressionEncoder()
@@ -55,6 +54,7 @@ trait StandardEncoders extends SpatialEncoders with TypedEncoders {
   implicit lazy val cellHistEncoder: ExpressionEncoder[CellHistogram] = ExpressionEncoder()
   implicit lazy val localCellStatsEncoder: ExpressionEncoder[LocalCellStatistics] = ExpressionEncoder()
 
+  implicit lazy val crsExpressionEncoder: ExpressionEncoder[CRS] = typedExpressionEncoder
   implicit lazy val uriEncoder: ExpressionEncoder[URI] = typedExpressionEncoder[URI]
   implicit lazy val neighborhoodEncoder: ExpressionEncoder[Neighborhood] = typedExpressionEncoder[Neighborhood]
   implicit lazy val targetCellEncoder: ExpressionEncoder[TargetCell] = typedExpressionEncoder[TargetCell]

--- a/core/src/main/scala/org/locationtech/rasterframes/ref/RFRasterSource.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/ref/RFRasterSource.scala
@@ -31,7 +31,7 @@ import geotrellis.vector.Extent
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.rf.{CrsUDT, RasterSourceUDT, TileUDT}
+import org.locationtech.rasterframes.encoders.StandardEncoders
 import org.locationtech.rasterframes.model.TileContext
 import org.locationtech.rasterframes.{NOMINAL_TILE_DIMS, rfConfig}
 
@@ -100,13 +100,7 @@ object RFRasterSource extends LazyLogging {
 
   def cacheStats = rsCache.stats()
 
-  implicit def rsEncoder: ExpressionEncoder[RFRasterSource] = {
-    // Makes sure UDTs are registered first
-    RasterSourceUDT
-    TileUDT
-    CrsUDT
-    ExpressionEncoder()
-  }
+  implicit lazy val rsEncoder: ExpressionEncoder[RFRasterSource] = StandardEncoders.rfRasterSourceEncoder
 
   def apply(source: URI): RFRasterSource =
     rsCache.get(

--- a/core/src/main/scala/org/locationtech/rasterframes/ref/RFRasterSource.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/ref/RFRasterSource.scala
@@ -31,7 +31,7 @@ import geotrellis.vector.Extent
 import org.apache.hadoop.conf.Configuration
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-import org.apache.spark.sql.rf.RasterSourceUDT
+import org.apache.spark.sql.rf.{CrsUDT, RasterSourceUDT, TileUDT}
 import org.locationtech.rasterframes.model.TileContext
 import org.locationtech.rasterframes.{NOMINAL_TILE_DIMS, rfConfig}
 
@@ -101,7 +101,10 @@ object RFRasterSource extends LazyLogging {
   def cacheStats = rsCache.stats()
 
   implicit def rsEncoder: ExpressionEncoder[RFRasterSource] = {
-    RasterSourceUDT // Makes sure UDT is registered first
+    // Makes sure UDTs are registered first
+    RasterSourceUDT
+    TileUDT
+    CrsUDT
     ExpressionEncoder()
   }
 

--- a/core/src/main/scala/org/locationtech/rasterframes/tiles/ProjectedRasterTile.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/tiles/ProjectedRasterTile.scala
@@ -27,7 +27,7 @@ import geotrellis.vector.{Extent, ProjectedExtent}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.locationtech.rasterframes.ref.ProjectedRasterLike
 import org.apache.spark.sql.catalyst.DefinedByConstructorParams
-import org.apache.spark.sql.rf.{CrsUDT, RasterSourceUDT, TileUDT}
+import org.locationtech.rasterframes.encoders.StandardEncoders
 
 /**
  * A Tile that's also like a ProjectedRaster, with delayed evaluation support.
@@ -59,11 +59,6 @@ object ProjectedRasterTile {
 
   def unapply(prt: ProjectedRasterTile): Option[(Tile, Extent, CRS)] = Some((prt.tile, prt.extent, prt.crs))
 
-  implicit lazy val projectedRasterTileEncoder: ExpressionEncoder[ProjectedRasterTile] = {
-    // Makes sure UDTs are registered first
-    RasterSourceUDT
-    TileUDT
-    CrsUDT
-    ExpressionEncoder()
-  }
+  implicit lazy val projectedRasterTileEncoder: ExpressionEncoder[ProjectedRasterTile] =
+    StandardEncoders.projectedRasterTileEncoder
 }

--- a/core/src/main/scala/org/locationtech/rasterframes/tiles/ProjectedRasterTile.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/tiles/ProjectedRasterTile.scala
@@ -27,6 +27,7 @@ import geotrellis.vector.{Extent, ProjectedExtent}
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 import org.locationtech.rasterframes.ref.ProjectedRasterLike
 import org.apache.spark.sql.catalyst.DefinedByConstructorParams
+import org.apache.spark.sql.rf.{CrsUDT, RasterSourceUDT, TileUDT}
 
 /**
  * A Tile that's also like a ProjectedRaster, with delayed evaluation support.
@@ -58,5 +59,11 @@ object ProjectedRasterTile {
 
   def unapply(prt: ProjectedRasterTile): Option[(Tile, Extent, CRS)] = Some((prt.tile, prt.extent, prt.crs))
 
-  implicit lazy val projectedRasterTileEncoder: ExpressionEncoder[ProjectedRasterTile] = ExpressionEncoder()
+  implicit lazy val projectedRasterTileEncoder: ExpressionEncoder[ProjectedRasterTile] = {
+    // Makes sure UDTs are registered first
+    RasterSourceUDT
+    TileUDT
+    CrsUDT
+    ExpressionEncoder()
+  }
 }

--- a/core/src/test/scala/org/locationtech/rasterframes/expressions/SFCIndexerSpec.scala
+++ b/core/src/test/scala/org/locationtech/rasterframes/expressions/SFCIndexerSpec.scala
@@ -24,7 +24,6 @@ package org.locationtech.rasterframes.expressions
 import geotrellis.proj4.{CRS, LatLng, WebMercator}
 import geotrellis.raster.CellType
 import geotrellis.vector._
-import org.apache.spark.sql.Encoders
 import org.apache.spark.sql.jts.JTSTypes
 import org.locationtech.geomesa.curve.{XZ2SFC, Z2SFC}
 import org.locationtech.rasterframes._
@@ -151,7 +150,6 @@ class SFCIndexerSpec extends TestEnvironment with Inspectors {
       val tile = TestData.randomTile(2, 2, CellType.fromName("uint8"))
       val prts = testExtents.map(reproject(crs)).map(ProjectedRasterTile(tile, _, crs))
 
-      implicit val enc = Encoders.tuple(ProjectedRasterTile.projectedRasterTileEncoder, Encoders.scalaInt)
       // The `id` here is to deal with Spark auto projecting single columns dataframes and needing to provide an encoder
       val df = prts.zipWithIndex.toDF("proj_raster", "id")
       withClue("XZ2") {

--- a/docs/src/main/paradox/release-notes.md
+++ b/docs/src/main/paradox/release-notes.md
@@ -2,6 +2,10 @@
 
 ## 0.10.x
 
+### 0.10.1
+
+* Fix UDTs registration ordering [#573](https://github.com/locationtech/rasterframes/pull/573)
+
 ### 0.10.0
 
 * Upgraded to Scala 2.12 , Spark 3.1.2, and GeoTrellis 3.6.0 (a subtantial accomplishment!)

--- a/pyrasterframes/src/main/python/setup.py
+++ b/pyrasterframes/src/main/python/setup.py
@@ -140,7 +140,7 @@ class PweaveNotebooks(PweaveDocs):
 # to throw a `NotImplementedError: Can't perform this operation for unregistered loader type`
 pytest = 'pytest>=4.0.0,<5.0.0'
 
-pyspark = 'pyspark==3.1.1'
+pyspark = 'pyspark==3.1.2'
 boto3 = 'boto3'
 deprecation = 'deprecation'
 descartes = 'descartes'

--- a/rf-notebook/src/main/docker/requirements-nb.txt
+++ b/rf-notebook/src/main/docker/requirements-nb.txt
@@ -1,4 +1,4 @@
-pyspark>=3.1
+pyspark==3.1.2
 gdal==3.1.2
 numpy
 pandas


### PR DESCRIPTION
Without this fix workers may try to access Encoders before registering UDTs.

Tested both 66cca65 and 8b5c165 within the k8s notebook.

The image to play with is ` quay.io/daunnc/rasterframes-notebook:0.10.1-SNAPSHOT`