### PR TITLE
Fix: Mask over double tiles uses int NODATA

### DIFF
--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/InverseMaskByDefined.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/InverseMaskByDefined.scala
@@ -60,7 +60,7 @@ case class InverseMaskByDefined(targetTile: Expression, maskTile: Expression)
     val (mask, maskCtx) = maskTileExtractor(row(maskInput))
     val result = maskEval(targetTile, mask,
       { (v, m) => if (isNoData(m)) v else NODATA },
-      { (v, m) => if (isNoData(m)) v else NODATA }
+      { (v, m) => if (isNoData(m)) v else Double.NaN }
     )
     toInternalRow(result, targetCtx)
   }

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/InverseMaskByValue.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/InverseMaskByValue.scala
@@ -73,7 +73,7 @@ case class InverseMaskByValue(targetTile: Expression, maskTile: Expression, mask
 
     val result = maskEval(targetTile, mask,
       { (v, m) => if (m != maskValue) NODATA else v },
-      { (v, m) => if (m != maskValue) NODATA else v }
+      { (v, m) => if (m != maskValue) Double.NaN else v }
     )
     toInternalRow(result, targetCtx)
   }

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/MaskByDefined.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/MaskByDefined.scala
@@ -59,7 +59,7 @@ case class MaskByDefined(targetTile: Expression, maskTile: Expression)
     val (mask, maskCtx) = maskTileExtractor(row(maskInput))
     val result = maskEval(targetTile, mask,
       { (v, m) => if (isNoData(m)) NODATA else v },
-      { (v, m) => if (isNoData(m)) NODATA else v }
+      { (v, m) => if (isNoData(m)) Double.NaN else v }
     )
     toInternalRow(result, targetCtx)
   }

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/MaskByValue.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/MaskByValue.scala
@@ -73,7 +73,7 @@ case class MaskByValue(targetTile: Expression, maskTile: Expression, maskValue: 
 
     val result = maskEval(targetTile, mask,
       { (v, m) => if (m == maskValue) NODATA else v },
-      { (v, m) => if (m == maskValue) NODATA else v }
+      { (v, m) => if (m == maskValue) Double.NaN else v }
     )
     toInternalRow(result, targetCtx)
   }

--- a/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/MaskByValues.scala
+++ b/core/src/main/scala/org/locationtech/rasterframes/expressions/transformers/MaskByValues.scala
@@ -73,7 +73,7 @@ case class MaskByValues(targetTile: Expression, maskTile: Expression, maskValues
 
     val result = maskEval(targetTile, mask,
       { (v, m) => if (maskValues.contains(m)) NODATA else v },
-      { (v, m) => if (maskValues.contains(m)) NODATA else v }
+      { (v, m) => if (maskValues.contains(m)) Double.NaN else v }
     )
 
     toInternalRow(result, targetCtx)


### PR DESCRIPTION
NODATA in Double context was returning Integer.MinValue instead